### PR TITLE
i965: Check result of make_surface() for miptree_create

### DIFF
--- a/src/mesa/drivers/dri/i965/intel_mipmap_tree.c
+++ b/src/mesa/drivers/dri/i965/intel_mipmap_tree.c
@@ -714,6 +714,9 @@ miptree_create(struct brw_context *brw,
          ISL_SURF_USAGE_DEPTH_BIT | ISL_SURF_USAGE_TEXTURE_BIT,
          BO_ALLOC_BUSY, 0, NULL);
 
+      if (!mt)
+         return NULL;
+
       if (needs_separate_stencil(brw, mt, format) &&
           !make_separate_stencil_surface(brw, mt)) {
          intel_miptree_release(&mt);


### PR DESCRIPTION
Since make_surface() can fail we need to check the result before dereferencing it.

Fixes https://bugs.launchpad.net/ubuntu/+source/gnome-shell/+bug/1760415