### PR TITLE
Update st_glsl_to_tgsi_array_merge.cpp

### DIFF
--- a/src/mesa/state_tracker/st_glsl_to_tgsi_array_merge.cpp
+++ b/src/mesa/state_tracker/st_glsl_to_tgsi_array_merge.cpp
@@ -132,6 +132,7 @@
 
 #include <iostream>
 
+using std::signbit;
 #include "st_glsl_to_tgsi_array_merge.h"
 
 #if __cplusplus >= 201402L


### PR DESCRIPTION
without the line "using std::signbit;", ninja fails with "../src/mesa/main/macros.h(774): error: identifier "signbit" is undefined"
with clang++/llvm 7.0.1, intel icpc 2018, and gcc 9.1.