### PR TITLE
egl: set TSD as NULL after deinit

### DIFF
--- a/src/egl/main/eglcurrent.c
+++ b/src/egl/main/eglcurrent.c
@@ -74,6 +74,7 @@ static inline void _eglFiniTSD(void)
 
       _egl_TSDInitialized = EGL_FALSE;
       _eglDestroyThreadInfo(t);
+      _eglSetTSD(NULL);
       tss_delete(_egl_TSD);
    }
    mtx_unlock(&_egl_TSDMutex);


### PR DESCRIPTION
When eglReleaseThread() is called from application's destructor (API with
attribute((destructor))), it crashes due to invalid memory access.

In this case, _egl_TLS is freed in the flow of _eglAtExit() as below but
_egl_TLS is not set to NULL.

 When eglReleaseThread() is called from application's destructor (API with
    __attribute__((destructor))), it crashes due to invalid memory access.

In this case, _egl_TLS is freed in the flow of _eglAtExit() as below but
egl_TLS is not set to NULL.

        eglDestroyThreadInfo
            |__ _eglFiniTSD
                    |__ _eglAtExit
                        |__ __run_exit_handlers
                            |__ exit

Later when the eglReleaseThread is called from application's destructor,
it ends-up accessing the freed _egl_TLS pointer.

        eglReleaseThread -> in libEGL_mesa
            |__ eglReleaseThread -> in libEGL(glvnd)
                 |__ destructor() -> App's destructor

To resolve the invalid access, setting the _egl_TLS pointer as NULL after freeing it.