### PR TITLE
wayland: damage_buffer send the correct damage rectangle

### DIFF
--- a/src/egl/drivers/dri2/platform_wayland.c
+++ b/src/egl/drivers/dri2/platform_wayland.c
@@ -1497,9 +1497,7 @@ try_damage_buffer(struct dri2_egl_surface *dri2_surf,
       const int *rect = &rects[i * 4];
 
       wl_surface_damage_buffer(dri2_surf->wl_surface_wrapper,
-                               rect[0],
-                               dri2_surf->base.Height - rect[1] - rect[3],
-                               rect[2], rect[3]);
+                               rect[0], rect[1], rect[2], rect[3]);
    }
    return EGL_TRUE;
 }


### PR DESCRIPTION
The damage rectangle is specified in buffer coordinates, where x and
y specify the upper left corner of the damage rectangle.

https://gitlab.freedesktop.org/wayland/wayland/-/blob/main/protocol/wayland.xml#L1737